### PR TITLE
Janet

### DIFF
--- a/about.rmd
+++ b/about.rmd
@@ -1,23 +1,21 @@
 ---
-title: "Untitled"
+title: "Biomarkers in Clinical Trials "
 output: html_document
 ---
 
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+The numbers of clinical trials are now rising in an unprecedented manner. The data they contain can be exploited to extract information about what human diseases are investigated and which are molecular biomarkers used in this massive pool of studies. In this contribution, we have applied artificial intelligent technologies to explore protein and gene biomarkers more frequently assessed in Clinical Trials data. We found over 4,300 genes measured in over 55,000 Clinical Trials involving 3,000 diseases. 
+
+
+
+## intervention type
+```{r, echo=FALSE,  message=F, warning=F,out.width="90%",  fig.cap = 'Figure 4:  Phases of the CTs containing biomarkers.'}
+# library(webr)
+# library(ggplot2)
+# datos <- as.data.frame(table( studies$study_type))
+# colnames(datos) <- c("intervention", "count")
+# 
+# PieDonut(datos,aes(intervention,count=count),r0=0.4,r1=0.6,explode=c(2,3),start=3*pi/2, showRatioThreshold = 0, labelposition = 1,  showRatioPie =F)
 ```
-
-## R Markdown
-
-This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
-
-When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
-
-```{r cars}
-summary(cars)
-```
-
-## Including Plots
 
 You can also embed plots, for example:
 
@@ -25,4 +23,5 @@ You can also embed plots, for example:
 plot(pressure)
 ```
 
-Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+
+ 

--- a/global.R
+++ b/global.R
@@ -10,7 +10,7 @@ library(kableExtra)
 
 pool <- dbPool(
   drv = MariaDB(),
-  host = "localhost",
+  host = "david.prib.upf.edu",
   username = "psebastian",
   password = "",
   dbname = "biomarkers_2022",
@@ -22,7 +22,7 @@ onStop(function() {
 
 
 createLink_Button <- function(text){
-  paste0('<button type="button" style="width: 100%; display:block;"
+  paste0('<button type="button" style="width: 70%; display:block;"
          class="btn btn-success action-button">', text, '</button>')
 }
 

--- a/global.R
+++ b/global.R
@@ -5,11 +5,12 @@ library(shinycssloaders)
 library(dplyr)
 library(bslib)
 library(pool)
-
+library(kableExtra)
 pool <- dbPool(
   drv = MariaDB(),
-  host = "david.prib.upf.edu",
+  host = "localhost",
   username = "psebastian",
+  password = "",
   dbname = "biomarkers_2022",
   port = 3306
 )
@@ -33,4 +34,13 @@ createLink_Symbol <- function(geneid, symbol){
 
 createLink_Name <- function(diseaseid, name){
   sprintf('<a href="https://meshb.nlm.nih.gov/record/ui?ui=%s" target="_blank">%s</a>',diseaseid, name)
+}
+
+
+createLink_NCIT <- function(nctid){
+  sprintf('<a href="https://clinicaltrials.gov/ct2/show/%s" target="_blank">%s</a>',nctid, nctid)
+}
+
+createLink_PMID <- function(pmid){
+  sprintf('<a href=https://pubmed.ncbi.nlm.nih.gov/%s" target="_blank">%s</a>',pmid, pmid)
 }

--- a/global.R
+++ b/global.R
@@ -20,10 +20,6 @@ onStop(function() {
   poolClose(pool)
 })
 
-loadData <- function(db, table) {
-  data <- tbl(db, table)
-  return(data)
-}
 
 createLink_Button <- function(text){
   paste0('<button type="button" style="width: 100%; display:block;"

--- a/global.R
+++ b/global.R
@@ -1,11 +1,13 @@
 library(shiny)
 library(RMariaDB)
 library(DT)
-library(shinycssloaders)
+library(shinycustomloader)
 library(dplyr)
 library(bslib)
 library(pool)
 library(kableExtra)
+
+
 pool <- dbPool(
   drv = MariaDB(),
   host = "localhost",
@@ -29,18 +31,18 @@ createLink_Button <- function(text){
 }
 
 createLink_Symbol <- function(geneid, symbol){
-  sprintf('<a href="https://www.ncbi.nlm.nih.gov/gene/%s" target="_blank">%s</a>',geneid, symbol)
+  sprintf("<a href='https://www.ncbi.nlm.nih.gov/gene/%s' target='_blank'>%s</a>",geneid, symbol)
 }
 
 createLink_Name <- function(diseaseid, name){
-  sprintf('<a href="https://meshb.nlm.nih.gov/record/ui?ui=%s" target="_blank">%s</a>',diseaseid, name)
+  sprintf("<a href='https://meshb.nlm.nih.gov/record/ui?ui=%s' target='_blank'>%s</a>",diseaseid, name)
 }
 
 
 createLink_NCIT <- function(nctid){
-  sprintf('<a href="https://clinicaltrials.gov/ct2/show/%s" target="_blank">%s</a>',nctid, nctid)
+  sprintf("<a href='https://clinicaltrials.gov/ct2/show/%s' target='_blank'>%s</a>",nctid, nctid)
 }
 
 createLink_PMID <- function(pmid){
-  sprintf('<a href=https://pubmed.ncbi.nlm.nih.gov/%s" target="_blank">%s</a>',pmid, pmid)
+  sprintf("<a href='https://pubmed.ncbi.nlm.nih.gov/%s' target='_blank'>%s</a>",pmid, pmid)
 }

--- a/server.R
+++ b/server.R
@@ -1,5 +1,9 @@
 function(input, output, session) {
   
+  ###############################################################
+  ################# REACTIVE VALUES #############################
+  ###############################################################
+  
   dt <- reactiveValues(dt_genes = NULL,
                        dt_diseases = NULL,
                        dt_studies = NULL,
@@ -7,12 +11,248 @@ function(input, output, session) {
                        dt_gd = NULL,
                        dt_publications = NULL,
                        Symbol = NULL,
-                       GeneId = NULL,
-                       DiseaseId = NULL)
-
-  observeEvent(input$header_title, {
-    updateNavbarPage(inputId = "navbarPage", selected = "about")
+                       DiseaseId = NULL,
+                       gd_symbol = NULL,
+                       gd_name = NULL)
+  
+  ###############################################################
+  
+  
+  ###############################################################
+  ################# MAIN QUERIES ################################
+  ###############################################################
+  
+  ### everytime we click on a tabSet, it will query MySQL
+  
+  observe({
+    
+    switch (req(input$navbarPage),
+      "genes" = {
+        dt$dt_genes <- pool %>%
+        tbl("genes") %>% 
+        collect() %>% 
+          mutate(Gene = createLink_Symbol(geneid, symbol))
+        },
+      
+      "diseases" = {
+        dt$dt_diseases <- pool %>% 
+          tbl("diseases") %>% 
+          collect() %>%
+          mutate( Condition = createLink_Name(diseaseid, name))
+      },
+      
+      # "studies" = {
+      #   dt$dt_studies <- pool %>% 
+      #     tbl("studies") %>% 
+      #     collect() 
+      #   },
+      
+      "gene_disease_summary" = {
+        dt$dt_gds <- pool %>%
+          tbl("gene_disease_summary") %>% 
+          collect() 
+        }, 
+      
+      "gene_disease" = {
+        query <- "select gd.*, g.symbol, d.name
+            from gene_disease as gd
+            left join genes as g
+            on gd.geneid = g.geneid
+            left join diseases as d
+            on gd.diseaseid = d.diseaseid"
+        dt$dt_gd <- pool %>%
+          dbGetQuery(query) %>%
+          collect() %>% 
+          filter( if( !is.null(dt$gd_symbol) ) symbol == dt$gd_symbol else TRUE ) %>%
+          filter( if( !is.null(dt$gd_name) ) name == dt$gd_name else TRUE )
+      },
+      
+      "publications" = {
+        query <- "select p.*, g.symbol, d.name
+            from publications as p
+            left join genes as g
+            on p.geneid = g.geneid
+            left join diseases as d
+            on p.mesh = d.diseaseid"
+        dt$dt_publications <- pool %>% 
+          dbGetQuery(query) %>% 
+          collect()
+      }
+    )
   })
+
+  ###############################################################
+  ###################### TABLES #################################
+  ###############################################################
+  
+  
+  ########################## GENES ##########################
+  
+  output$genes <- DT::renderDataTable({
+    dt$dt_genes %>%
+      rename( "type of gene" = type_of_gene,
+              "protein class" = PROTEIN_CLASS_NAMES,
+              "DPI" = dpi, "DSI" = dsi, "pLI"=pli,
+              "year initial" = year_initial, "year final" = year_final, 
+              "Num. Clin.Trials" =  nclinicaltrials, 
+              "Num. Diseases" = ndiseases, "Num. Pmids" = npmids)  %>% 
+      select(Gene, description, `type of gene`, DSI, DPI, pLI,`protein class`,
+             `Num. Clin.Trials`, `Num. Diseases`, `Num. Pmids`,
+             `year initial`, `year final`
+      ) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
+      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
+    }, 
+    filter = "top",
+    options = list(scrollX = TRUE, dom = 'ltipr', pageLength = 10,
+                   columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+    rownames = FALSE,
+    escape = FALSE,
+    selection = list(mode = 'single', target = 'cell'))
+  
+  
+  geneProxy <- dataTableProxy('genes')
+  
+  observeEvent(req(input$genes_cells_selected), {
+    cell_clicked <- input$genes_cell_clicked
+    geneProxy %>%  selectCells(NULL)
+    if(cell_clicked$col == 0){
+      value <- cell_clicked$value
+      dt$Symbol <- dt$dt_genes %>% 
+        filter(Gene == value) %>% 
+        select(geneid) %>% 
+        as.character
+      updateNavbarPage(inputId = "navbarPage", selected = "gene_disease_summary")
+    }
+  })
+  
+  
+  ########################## DISEASES ##########################
+  
+  output$diseases <- DT::renderDataTable({
+    dt$dt_diseases %>%
+      rename("Semantic Type" = sty, 
+             "Num. Biomarkers" = nbiomarkers, 
+             "year initial" = year_initial, "year final" = year_final, 
+             "Num. Clin.Trials" =  nclinicaltrials, 
+             "Num. Pmids" = npmids) %>%
+      select(Condition, "Semantic Type",  "Num. Biomarkers" ,
+             `Num. Clin.Trials`,   `Num. Pmids`,
+             `year initial`, `year final`) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
+      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
+  },
+  filter = "top",
+  selection = list(mode = 'single', target = 'cell'),
+  options = list(dom = 'ltipr', columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+  rownames = FALSE,
+  escape = FALSE)
+  
+  diseaseProxy <- dataTableProxy('diseases')
+  
+  observeEvent(req(input$diseases_cells_selected), {
+    cell_clicked <- input$diseases_cell_clicked
+    diseaseProxy %>% selectCells(NULL)
+    if(cell_clicked$col == 0){
+      value <- cell_clicked$value
+      dt$DiseaseId <- dt$dt_diseases %>% 
+        filter(Condition == value) %>% 
+        select(diseaseid) %>% 
+        as.character()
+      updateNavbarPage(inputId = "navbarPage", selected = "gene_disease_summary")
+    }
+  })
+
+
+  
+  ########################## GENE-DISEASE SUMMARY ##########################
+  
+  output$gene_disease_summary <- DT::renderDataTable({
+    dt$dt_gds %>% 
+      filter( if( !is.null(dt$Symbol) ) geneid == dt$Symbol else TRUE ) %>% 
+      filter( if( !is.null(dt$DiseaseId) ) diseaseid == dt$DiseaseId else TRUE ) %>%
+      select(-geneid, -diseaseid, -id) %>% 
+      rename( "Gene" = symbol, "Condition" = name,  
+              "year initial" = year_initial, "year final" = year_final, 
+              "Num. Clin.Trials" =  nclinicaltrials, 
+              "Num. Pmids" = npmids)  %>% 
+      select(Gene, Condition, 
+             `Num. Clin.Trials`,   `Num. Pmids`,
+             `year initial`, `year final`) %>%
+      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`)) %>% 
+      arrange(desc(`Num. Clin.Trials`) ) 
+  }, filter = "top",
+  options = list(dom = 'ltipr',
+                 columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+  selection = list(mode = 'single', target = 'cell'),
+  escape = FALSE,
+  rownames = FALSE,
+  callback = JS("table.on('click.dt', 'tr',
+                  function() {
+                    var data = table.rows(this).data().toArray();;
+                    Shiny.setInputValue('gds_data', data);
+                  });")
+  )
+
+  gdsProxy <- dataTableProxy("gene_disease_summary")
+  
+  observeEvent(input$gds_data, {
+    value <- input$gene_disease_summary_cell_clicked
+    gdsProxy %>% selectCells(NULL)
+    col <- value$col
+    if(col == "2"){
+      dt$gd_symbol <- input$gds_data[1]
+      dt$gd_name <- input$gds_data[2]
+      updateNavbarPage( inputId = "navbarPage", selected = "gene_disease")
+    }
+  })
+  
+  
+  ########################## GENE-DISEASE ##########################
+  
+  output$gene_disease <- DT::renderDataTable({
+    dt$dt_gd %>%
+      mutate(symbol = createLink_Symbol(geneid, symbol),
+             nctid =   createLink_NCIT(nctid),
+           #  pmid =   createLink_PMID(pmid),
+             name = createLink_Name(diseaseid, name)) %>%
+      select(-id, -sentenceHtml, -geneid, -diseaseid) %>%
+      relocate(symbol, .after=nctid) %>%
+      relocate(name, .after=symbol) %>% 
+      rename("Gene" = symbol, "Condition" = name, 
+             "NCT ID" = nctid, "Measurement" = sentence, 
+             "Num. Pmids" = npmids,
+             "Biomarker Type" = bmtype ) %>%  arrange(desc(`Num. Pmids`) )
+      
+  },
+  escape = FALSE,
+  filter = "top",
+  options = list(dom = 'ltipr',
+                 columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+  rownames = FALSE)
+  
+  
+  ########################## PUBLICATIONS ##########################
+  
+  output$publications <- DT::renderDataTable({
+    dt$dt_publications %>%
+      mutate(symbol = createLink_Symbol(geneid, symbol),
+             nctid =   createLink_NCIT(nctid),
+              pmid =   createLink_PMID(pmid),
+             name = createLink_Name(mesh, name)) %>%
+      select(-id, -geneid, -mesh) %>%
+      rename("Gene" = symbol, "Condition" = name, 
+             "NCT ID" = nctid ) %>%  arrange(desc(year) )
+    
+  }, filter = "top",
+  options = list(dom = 'ltipr',
+                 columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+  selection = list(mode = 'single', target = 'cell'),
+  escape = FALSE,
+  rownames = FALSE)  
+  
+  
+  ###############################################################
+  ############### BUTTONS FOR RELOAD DATA #######################
+  ###############################################################
   
   observeEvent(input$reload1, {
     dt$Symbol <- NULL
@@ -34,219 +274,35 @@ function(input, output, session) {
       dbGetQuery(query) %>%
       collect()
   })
-  
-  observe({
-    
-    switch (req(input$navbarPage),
-      "genes" = {
-        dt$dt_genes <- pool %>%
-        tbl("genes") %>% 
-        collect() %>% 
-          mutate(Gene = createLink_Symbol(geneid, symbol))
-        },
-      
-      "diseases" = {
-        dt$dt_diseases <- pool %>% 
-          tbl("diseases") %>% 
-          collect() %>%
-          mutate( Condition = createLink_Name(diseaseid, name))
-      },
-      
-      "studies" = {
-        dt$dt_studies <- pool %>% 
-          tbl("studies") %>% 
-          collect() 
-        },
-      
-      "gene_disease_summary" = {
-        dt$dt_gds <- pool %>%
-          tbl("gene_disease_summary") %>% 
-          collect() 
-        }, 
-      
-      "gene_disease" = {
-        query <- "select gd.*, g.symbol, d.name
-            from gene_disease as gd
-            left join genes as g
-            on gd.geneid = g.geneid
-            left join diseases as d
-            on gd.diseaseid = d.diseaseid"
-        dt$dt_gd <- pool %>%
-          dbGetQuery(query) %>%
-          collect() %>% 
-          filter( if( !is.null(dt$Symbol) ) symbol == dt$Symbol else TRUE ) %>% 
-          filter( if( !is.null(dt$DiseaseId) ) diseaseid == dt$DiseaseId else TRUE )
-      },
-      
-      "publications" = {
-        query <- "select p.*, g.symbol, d.name
-            from publications as p
-            left join genes as g
-            on p.geneid = g.geneid
-            left join diseases as d
-            on p.mesh = d.diseaseid"
-        dt$dt_publications <- pool %>% 
-          dbGetQuery(query) %>% 
-          collect()
-      }
-    )
-  })
 
   
-  output$genes <- DT::renderDataTable({
-    dt$dt_genes %>%
-      rename( "type of gene" = type_of_gene,
-              "protein class" = PROTEIN_CLASS_NAMES,
-              "DPI" = dpi, "DSI" = dsi, "pLI"=pli,
-              "year initial" = year_initial, "year final" = year_final, 
-              "Num. Clin.Trials" =  nclinicaltrials, 
-              "Num. Diseases" = ndiseases, "Num. Pmids" = npmids)  %>% 
-      select(Gene, description, `type of gene`, DSI, DPI, pLI,`protein class`,
-             `Num. Clin.Trials`, `Num. Diseases`, `Num. Pmids`,
-             `year initial`, `year final`
-      ) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
-      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
-    }, 
-    filter = "top",
-    options = list(scrollX = TRUE, dom = 'ltipr', pageLength = 10),
-    rownames = FALSE,
-    escape = FALSE,
-    selection = list(mode = 'single', target = 'cell'))
+  ###############################################################
   
+  ### Redirect Header title to "About" page  
   
-  geneProxy <- dataTableProxy('genes')
-  
-  observeEvent(req(input$genes_cells_selected), {
-    cell_clicked <- input$genes_cell_clicked
-    geneProxy %>%  selectCells(NULL)
-    if(cell_clicked$col == 0){
-      value <- cell_clicked$value
-      dt$Symbol <- dt$dt_genes %>% 
-        filter(Gene == value) %>% 
-        select(geneid) %>% 
-        as.character
-      updateNavbarPage(inputId = "navbarPage", selected = "gene_disease_summary")
-    }
+  observeEvent(input$header_title, {
+    updateNavbarPage(inputId = "navbarPage", selected = "about")
   })
-  
-  output$diseases <- DT::renderDataTable({
-    dt$dt_diseases %>%
-      rename("Semantic Type" = sty, 
-             "Num. Biomarkers" = nbiomarkers, 
-             "year initial" = year_initial, "year final" = year_final, 
-             "Num. Clin.Trials" =  nclinicaltrials, 
-             "Num. Pmids" = npmids) %>%
-      select(Condition, "Semantic Type",  "Num. Biomarkers" ,
-             `Num. Clin.Trials`,   `Num. Pmids`,
-             `year initial`, `year final`) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
-      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
-  },
-  filter = "top",
-  selection = list(mode = 'single', target = 'cell'),
-  options = list(dom = 'ltipr'),
-  rownames = FALSE,
-  escape = FALSE)
-  
-  diseaseProxy <- dataTableProxy('diseases')
-  
-  observeEvent(req(input$diseases_cells_selected), {
-    cell_clicked <- input$diseases_cell_clicked
-    diseaseProxy %>% selectCells(NULL)
-    if(cell_clicked$col == 0){
-      value <- cell_clicked$value
-      dt$DiseaseId <- dt$dt_diseases %>% 
-        filter(Condition == value) %>% 
-        select(diseaseid) %>% 
-        as.character()
-      updateNavbarPage(inputId = "navbarPage", selected = "gene_disease_summary")
-    }
-  })
-  
-  output$studies <- DT::renderDataTable({
-    dt$dt_studies %>% 
-      rename(   "NCT ID" = nctid, "Brief Title" = brief_title, 
-                "Official Title" = official_title,  
-                "Num. GDAS" = ngdas, "Num. Genes" = ngenes, "Num. Diseases" = ndiseases,
-                "Num Pmids" = npmids, "Study Type" = study_type       )  %>% 
-      select("NCT ID" , "Brief Title",  "Official Title", "Study Type", "Official Title", 
-             "Num. GDAS", "Num. Genes", "Num. Diseases", "Num Pmids") %>%
-      arrange(desc(`Num. GDAS`) ) %>%
-      mutate(`NCT ID` = createLink_NCIT(`NCT ID`))
-  }, filter = "top",
-  options = list(scrollX = TRUE, dom = 'ltipr', pageLength = 10),
-  rownames = FALSE,
-  escape = FALSE,
-  selection = list(mode = 'single', target = 'cell'))
-
-  ### use reactive in order to filter geneid and diseaseid for gene-disease table?
-  g_d_summary <- reactive({
-    dt$dt_gds %>% 
-      filter( if( !is.null(dt$Symbol) ) geneid == dt$Symbol else TRUE ) %>% 
-      filter( if( !is.null(dt$DiseaseId) ) diseaseid == dt$DiseaseId else TRUE ) %>%
-      select(-geneid, -diseaseid, -id) %>% 
-      rename( "Gene" = symbol, "Condition" = name,  
-              "year initial" = year_initial, "year final" = year_final, 
-              "Num. Clin.Trials" =  nclinicaltrials, 
-              "Num. Pmids" = npmids)  %>% 
-      select(Gene, Condition, 
-             `Num. Clin.Trials`,   `Num. Pmids`,
-             `year initial`, `year final`) %>%
-      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`)) %>% 
-      arrange(desc(`Num. Clin.Trials`) ) 
-  })
-  
-  output$gene_disease_summary <- DT::renderDataTable({
-    g_d_summary()
-  }, filter = "top",
-  options = list(dom = 'ltipr'),
-  selection = list(mode = 'single', target = 'cell'),
-  escape = FALSE,
-  rownames = FALSE)
-  
-  observeEvent(req(input$gene_disease_summary_cells_selected), {
-    value <- input$gene_disease_summary_cell_clicked
-    col <- value$col
-    if(col == "2"){
-      str(input$gene_disease_summary_cells_selected)
-      # dt$Symbol <- dt$dt_gds[rows,3, drop = TRUE]
-      # dt$DiseaseId <- dt$dt_gds[rows, 2, drop = TRUE]
-      updateNavbarPage(inputId = "navbarPage", selected = "gene_disease")
-    }
-  })
-  
-  output$gene_disease <- DT::renderDataTable({
-    dt$dt_gd %>%
-      mutate(symbol = createLink_Symbol(geneid, symbol),
-             nctid =   createLink_NCIT(nctid),
-           #  pmid =   createLink_PMID(pmid),
-             name = createLink_Name(diseaseid, name)) %>%
-      select(-id, -sentenceHtml, -geneid, -diseaseid) %>%
-      relocate(symbol, .after=nctid) %>%
-      relocate(name, .after=symbol) %>% 
-      rename("Gene" = symbol, "Condition" = name, 
-             "NCT ID" = nctid, "Measurement" = sentence, 
-             "Num. Pmids" = npmids,
-             "Biomarker Type" = bmtype ) %>%  arrange(desc(`Num. Pmids`) )
-      
-  },
-  escape = FALSE,
-  filter = "top",
-  options = list(dom = 'ltipr'),
-  rownames = FALSE) 
-  
-  output$publications <- DT::renderDataTable({
-    dt$dt_publications %>%
-      mutate(symbol = createLink_Symbol(geneid, symbol),
-             nctid =   createLink_NCIT(nctid),
-              pmid =   createLink_PMID(pmid),
-             name = createLink_Name(mesh, name)) %>%
-      select(-id, -geneid, -mesh) %>%
-      rename("Gene" = symbol, "Condition" = name, 
-             "NCT ID" = nctid ) %>%  arrange(desc(year) )
-    
-  }, filter = "top",
-  options = list(dom = 'ltipr'),
-  selection = list(mode = 'single', target = 'cell'),
-  escape = FALSE,
-  rownames = FALSE)  
 }
+
+
+# LEGACY CODE
+# 
+# ########################## STUDIES ##########################
+# 
+# output$studies <- DT::renderDataTable({
+#   dt$dt_studies %>% 
+#     rename(   "NCT ID" = nctid, "Brief Title" = brief_title, 
+#               "Official Title" = official_title,  
+#               "Num. GDAS" = ngdas, "Num. Genes" = ngenes, "Num. Diseases" = ndiseases,
+#               "Num Pmids" = npmids, "Study Type" = study_type       )  %>% 
+#     select("NCT ID" , "Brief Title",  "Official Title", "Study Type", "Official Title", 
+#            "Num. GDAS", "Num. Genes", "Num. Diseases", "Num Pmids") %>%
+#     arrange(desc(`Num. GDAS`) ) %>%
+#     mutate(`NCT ID` = createLink_NCIT(`NCT ID`))
+# }, filter = "top",
+# options = list(scrollX = TRUE, dom = 'ltipr', pageLength = 10,
+#                columnDefs = list(list(className = 'dt-center', targets ="_all"))),
+# rownames = FALSE,
+# escape = FALSE,
+# selection = list(mode = 'single', target = 'cell'))

--- a/server.R
+++ b/server.R
@@ -41,44 +41,19 @@ function(input, output, session) {
       "genes" = {
         dt$dt_genes <- pool %>%
         tbl("genes") %>% 
-        collect() %>% 
-          mutate(symbol = createLink_Symbol(geneid, symbol)) %>%
-          rename( "Gene" = symbol, "type of gene" = type_of_gene,
-                  "protein class" = PROTEIN_CLASS_NAMES,
-                 "DPI" = dpi, "DSI" = dsi, "pLI"=pli,
-                 "year initial" = year_initial, "year final" = year_final, 
-               "Num. Clin.Trials" =  nclinicaltrials, 
-               "Num. Diseases" = ndiseases, "Num. Pmids" = npmids)  %>% 
-          select(Gene, description, `type of gene`, DSI, DPI, pLI,`protein class`,
-                 `Num. Clin.Trials`, `Num. Diseases`, `Num. Pmids`,
-                 `year initial`, `year final`
-                 ) %>%  arrange(desc(`Num. Clin.Trials`) )
+        collect() 
         },
       
       "diseases" = {
         dt$dt_diseases <- pool %>% 
           tbl("diseases") %>% 
-          collect() %>% mutate(  name = createLink_Name(diseaseid, name)) %>%
-        rename("Condition" = name, "Semantic Type" = sty, 
-                               "Num. Biomarkers" = nbiomarkers, 
-                               "year initial" = year_initial, "year final" = year_final, 
-                               "Num. Clin.Trials" =  nclinicaltrials, 
-                               "Num. Pmids" = npmids) %>%
-        select(Condition, "Semantic Type",  "Num. Biomarkers" ,
-               `Num. Clin.Trials`,   `Num. Pmids`,
-               `year initial`, `year final`) %>%  arrange(desc(`Num. Clin.Trials`) )
+          collect() 
       },
       
       "studies" = {
         dt$dt_studies <- pool %>% 
           tbl("studies") %>% 
-          collect() %>% 
-          rename(   "NCT ID" = nctid, "Brief Title" = brief_title, 
-                    "Official Title" = official_title,  
-                    "Num. GDAS" = ngdas, "Num. Genes" = ngenes, "Num. Diseases" = ndiseases,
-                    "Num Pmids" = npmids, "Study Type" = study_type       )  %>% 
-          select("NCT ID" , "Brief Title",  "Official Title", "Study Type", "Official Title", 
-                 "Num. GDAS", "Num. Genes", "Num. Diseases", "Num Pmids") %>%  arrange(desc(`Num. GDAS`) )
+          collect() 
         },
       
       "gene_disease_summary" = {
@@ -86,17 +61,7 @@ function(input, output, session) {
           tbl("gene_disease_summary") %>% 
           collect() %>% 
           filter( if( !is.null(dt$Symbol) ) symbol == dt$Symbol else TRUE ) %>% 
-          filter( if( !is.null(dt$DiseaseId) ) diseaseid == dt$DiseaseId else TRUE ) %>%
-          select(-geneid, -diseaseid, -id) %>% 
-          rename(            "Gene" = symbol, "Condition" = name,  
-                 "year initial" = year_initial, "year final" = year_final, 
-                 "Num. Clin.Trials" =  nclinicaltrials, 
-                  "Num. Pmids" = npmids)  %>% 
-          select(Gene, Condition, 
-                 `Num. Clin.Trials`,   `Num. Pmids`,
-                 `year initial`, `year final`
-          )%>%  arrange(desc(`Num. Clin.Trials`) )
-
+          filter( if( !is.null(dt$DiseaseId) ) diseaseid == dt$DiseaseId else TRUE )
         }, 
       
       "gene_disease" = {
@@ -130,6 +95,17 @@ function(input, output, session) {
   
   output$genes <- DT::renderDataTable({
     dt$dt_genes %>% 
+      mutate(symbol = createLink_Symbol(geneid, symbol)) %>%
+      rename( "Gene" = symbol, "type of gene" = type_of_gene,
+              "protein class" = PROTEIN_CLASS_NAMES,
+              "DPI" = dpi, "DSI" = dsi, "pLI"=pli,
+              "year initial" = year_initial, "year final" = year_final, 
+              "Num. Clin.Trials" =  nclinicaltrials, 
+              "Num. Diseases" = ndiseases, "Num. Pmids" = npmids)  %>% 
+      select(Gene, description, `type of gene`, DSI, DPI, pLI,`protein class`,
+             `Num. Clin.Trials`, `Num. Diseases`, `Num. Pmids`,
+             `year initial`, `year final`
+      ) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
       mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
     }, 
     filter = "top",
@@ -156,7 +132,16 @@ function(input, output, session) {
   })
   
   output$diseases <- DT::renderDataTable({
-    dt$dt_diseases %>% 
+    dt$dt_diseases  %>%
+      mutate(  name = createLink_Name(diseaseid, name)) %>%
+      rename("Condition" = name, "Semantic Type" = sty, 
+             "Num. Biomarkers" = nbiomarkers, 
+             "year initial" = year_initial, "year final" = year_final, 
+             "Num. Clin.Trials" =  nclinicaltrials, 
+             "Num. Pmids" = npmids) %>%
+      select(Condition, "Semantic Type",  "Num. Biomarkers" ,
+             `Num. Clin.Trials`,   `Num. Pmids`,
+             `year initial`, `year final`) %>%  arrange(desc(`Num. Clin.Trials`) ) %>% 
       mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
   },
   filter = "top",
@@ -181,7 +166,13 @@ function(input, output, session) {
   })
   
   output$studies <- DT::renderDataTable({
-    dt$dt_studies %>%
+    dt$dt_studies %>% 
+      rename(   "NCT ID" = nctid, "Brief Title" = brief_title, 
+                "Official Title" = official_title,  
+                "Num. GDAS" = ngdas, "Num. Genes" = ngenes, "Num. Diseases" = ndiseases,
+                "Num Pmids" = npmids, "Study Type" = study_type       )  %>% 
+      select("NCT ID" , "Brief Title",  "Official Title", "Study Type", "Official Title", 
+             "Num. GDAS", "Num. Genes", "Num. Diseases", "Num Pmids") %>%  arrange(desc(`Num. GDAS`) ) %>%
       mutate(`NCT ID` = createLink_NCIT(`NCT ID`))
   }, filter = "top",
   options = list(scrollX = TRUE, dom = 'ltipr', pageLength = 10),
@@ -191,8 +182,17 @@ function(input, output, session) {
 
 
   output$gene_disease_summary <- DT::renderDataTable({
-    dt$dt_gds %>%
-      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`))
+    dt$dt_gds  %>%
+      select(-geneid, -diseaseid, -id) %>% 
+      rename( "Gene" = symbol, "Condition" = name,  
+              "year initial" = year_initial, "year final" = year_final, 
+              "Num. Clin.Trials" =  nclinicaltrials, 
+              "Num. Pmids" = npmids)  %>% 
+      select(Gene, Condition, 
+             `Num. Clin.Trials`,   `Num. Pmids`,
+             `year initial`, `year final`) %>%
+      mutate(`Num. Clin.Trials` = createLink_Button(`Num. Clin.Trials`)) %>% 
+      arrange(desc(`Num. Clin.Trials`) )
   }, filter = "top",
   options = list(dom = 'ltipr'),
   selection = list(mode = 'single', target = 'cell'),

--- a/ui.R
+++ b/ui.R
@@ -1,48 +1,22 @@
 navbarPage(
   id = "navbarPage",
   tags$link(rel = "stylesheet", type = "text/css", href="custom-css.css"),
-  # tags$style(HTML("
-  #     span.disease {
-  #       background-color: #7774D1;
-  #       color: white;
-  #     }
-  #     span.disease.covid.cdisease {
-  #       background-color: rgb(67, 69, 233);
-  #       color: white; 
-  #     }
-  #     span.gene {
-  #       background-color: #FF8000;
-  #       color: white;
-  #     }
-  #     .navbar.navbar-default ul.nav.navbar-nav > li > a.active {
-  #       background-color: #778899;
-  #     }
-  #     table.dataTable tr.active td, table.dataTable td.active {
-  #       background-color: #DAA520 !important;
-  #     }
-  #     #header_title {
-  #       color: #FFFFF0;
-  #       font-weight: bold;
-  #     }
-  #     "
-  #     )
-  # ),
   title = actionLink("header_title","CLINICAL TRIALS BIOMARKERS", icon = icon("home")),
   collapsible = TRUE,
   theme = bs_theme(bootswatch = "yeti"),
   nav_spacer(),
   tabPanel("About", value = "about", includeMarkdown("about.rmd")),
-  tabPanel("Genes", value = "genes", withSpinner(DT::dataTableOutput("genes"))),
-  tabPanel("Diseases", value = "diseases", withSpinner(DTOutput("diseases"))),
-  tabPanel("Studies",  value = "studies", withSpinner(DTOutput("studies" ))),
+  tabPanel("Genes", value = "genes", withLoader(DT::dataTableOutput("genes"))),
+  tabPanel("Diseases", value = "diseases", withLoader(DTOutput("diseases"))),
+  tabPanel("Studies",  value = "studies", withLoader(DTOutput("studies" ))),
   tabPanel("Gene-Disease Summary",  value = "gene_disease_summary",
            actionButton("reload1", "Reload Data"),
            hr(),
-           withSpinner(DTOutput("gene_disease_summary"))),
+           withLoader(DTOutput("gene_disease_summary"))),
   tabPanel("Gene-Disease",  value = "gene_disease",
            actionButton("reload2", "Reload Data"),
            hr(),
-           withSpinner(DTOutput("gene_disease"))),
-  tabPanel("Publications",  value = "publications", withSpinner(DTOutput("publications"))),
+           withLoader(DTOutput("gene_disease"))),
+  tabPanel("Publications",  value = "publications", withLoader(DTOutput("publications"))),
   footer = textOutput("text")
 )

--- a/ui.R
+++ b/ui.R
@@ -6,17 +6,18 @@ navbarPage(
   theme = bs_theme(bootswatch = "yeti"),
   nav_spacer(),
   tabPanel("About", value = "about", includeMarkdown("about.rmd")),
-  tabPanel("Genes", value = "genes", withLoader(DT::dataTableOutput("genes"))),
-  tabPanel("Diseases", value = "diseases", withLoader(DTOutput("diseases"))),
-  tabPanel("Studies",  value = "studies", withLoader(DTOutput("studies" ))),
-  tabPanel("Gene-Disease Summary",  value = "gene_disease_summary",
+  tabPanel("Biomarkers", value = "genes", withLoader(DT::dataTableOutput("genes"))),
+  tabPanel("Conditions", value = "diseases", withLoader(DTOutput("diseases"))),
+  tabPanel("Summary",  value = "gene_disease_summary",
            actionButton("reload1", "Reload Data"),
            hr(),
            withLoader(DTOutput("gene_disease_summary"))),
-  tabPanel("Gene-Disease",  value = "gene_disease",
+  tabPanel("Measurements",  value = "gene_disease",
            actionButton("reload2", "Reload Data"),
            hr(),
            withLoader(DTOutput("gene_disease"))),
   tabPanel("Publications",  value = "publications", withLoader(DTOutput("publications"))),
   footer = textOutput("text")
 )
+
+#tabPanel("Studies",  value = "studies", withLoader(DTOutput("studies" ))),


### PR DESCRIPTION
- fixed link between Gene-Disease Summary and Gene-Disease (potentially, this new way could be used in other tables)
- made all columns center-aligned
- made buttons smaller
- changed name of tabsets : 

1. Genes > Biomakers
2. Diseases > Conditions
3. Gene-Disease Summary > Summary
4. Gene-Disease > Measurements

- took out Publications table (commented out until further notice)